### PR TITLE
:wrench: change to codeclimate for coverage and quality.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,15 @@ node_js:
   - '6'
 install:
   - yarn
-  - npm i codecov -g
 cache:
   yarn: true
   directories:
     - node_modules
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
 script:
-  - npm run coverage
+  - nyc --reporter=lcov mocha --compilers js:babel-core/register test
 after_success:
-  - nyc report --reporter=text-lcov > coverage.lcov && codecov
+  - ./cc-test-reporter after-build -t lcov --exit-code $TRAVIS_TEST_RESULT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased][]
+- Change to codeclimate for coverage and quality
 
 ## [1.5.0][] - 2018-06-02
 - Patch readme formatting again.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # TODO-MONTH
 
-
-[![Maintenance status](https://raw.githubusercontent.com/one19/project-status/master/cache/todo-month/maintained.svg?sanitize=true)](https://github.com/one19/project-status) [![published on npm!](https://raw.githubusercontent.com/one19/project-status/master/cache/todo-month/npm.svg?sanitize=true)](https://www.npmjs.com/package/todo-month) [![Known Vulnerabilities](https://snyk.io/test/github/one19/todo-month/badge.svg)](https://snyk.io/test/github/one19/todo-month) [![Testing Status](https://travis-ci.org/one19/todo-month.svg?branch=master)](https://travis-ci.org/one19/todo-month) [![codecov](https://codecov.io/gh/one19/todo-month/branch/master/graph/badge.svg)](https://codecov.io/gh/one19/todo-month)
+[![Maintenance status](https://raw.githubusercontent.com/one19/project-status/master/cache/todo-month/maintained.svg?sanitize=true)](https://github.com/one19/project-status) [![published on npm!](https://raw.githubusercontent.com/one19/project-status/master/cache/todo-month/npm.svg?sanitize=true)](https://www.npmjs.com/package/todo-month) [![Known Vulnerabilities](https://snyk.io/test/github/one19/todo-month/badge.svg)](https://snyk.io/test/github/one19/todo-month) [![Testing Status](https://travis-ci.org/one19/todo-month.svg?branch=master)](https://travis-ci.org/one19/todo-month) [![Test Coverage](https://api.codeclimate.com/v1/badges/2f4e240b4d884e79bad4/test_coverage)](https://codeclimate.com/github/one19/todo-month/test_coverage) [![Maintainability](https://api.codeclimate.com/v1/badges/2f4e240b4d884e79bad4/maintainability)](https://codeclimate.com/github/one19/todo-month/maintainability)
 
 ---
 


### PR DESCRIPTION
codeclimate offers pretty neat code quality analytics, and also can get our coverage reports. This switches the project over.